### PR TITLE
Prince Strict Mode

### DIFF
--- a/src/main/kotlin/me/odinmain/features/impl/dungeon/Mimic.kt
+++ b/src/main/kotlin/me/odinmain/features/impl/dungeon/Mimic.kt
@@ -33,7 +33,7 @@ object Mimic : Module(
     private val mimicDropdown by DropdownSetting("Mimic Dropdown")
     private val mimicMessageToggle by BooleanSetting("Toggle Mimic Message", true, desc = "Toggles the mimic killed message.").withDependency { mimicDropdown }
     val mimicMessage by StringSetting("Mimic Message", "Mimic Killed!", 128, desc = "Message sent when mimic is detected as killed.").withDependency { mimicDropdown && mimicMessageToggle }
-    private val mimicReset by ActionSetting("Mimic Killed", desc = "Sends Mimic killed message in party chat.") { mimicKilled() }.withDependency{ mimicDropdown }
+    private val mimicReset by ActionSetting("Mimic Killed", desc = "Sends Mimic killed message in party chat.") { mimicKilled() }.withDependency { mimicDropdown }
 
     private val princeDropdown by DropdownSetting("Prince Dropdown")
     private val princeDetection by BooleanSetting("Max Reborn Attribute", false, desc = "Enables prince detection. Only enable if you have 100% extra score chance from princes.").withDependency { princeDropdown }
@@ -60,7 +60,7 @@ object Mimic : Module(
             this is EntityOtherPlayerMP && getEntityTexture(this) == PRINCE_TEXTURE && princeDetection -> {
                 val dist = mc.thePlayer.getDistanceToEntity(this)
                 if ((dist > princeRange) ||
-                    (princeStrict && DungeonUtils.dungeonTeammatesNoSelf.any {(it.entity?.getDistanceToEntity(this) ?: 999f) <= dist })
+                    (princeStrict && DungeonUtils.dungeonTeammatesNoSelf.any {(it.entity?.getDistanceToEntity(this) ?: Float.MAX_VALUE) <= dist })
                 ) return@with
                 princeKilled()
             }

--- a/src/main/kotlin/me/odinmain/utils/skyblock/dungeon/DungeonListener.kt
+++ b/src/main/kotlin/me/odinmain/utils/skyblock/dungeon/DungeonListener.kt
@@ -129,17 +129,15 @@ object DungeonListener {
 
     @SubscribeEvent
     fun onEntityJoin(event: EntityJoinWorldEvent) {
-        with (event.entity as? EntityPlayer ?: return) {
-            val teammate = dungeonTeammatesNoSelf.find { it.name == event.entity.name } ?: return
-            teammate.entity = this
+        (event.entity as? EntityPlayer)?.let { player ->
+            dungeonTeammatesNoSelf.find { it.name == player.name }?.let { it.entity = player }
         }
     }
 
     @SubscribeEvent
     fun onEntityLeave(event: EntityLeaveWorldEvent) {
-        with (event.entity as? EntityPlayer ?: return) {
-            val teammate = dungeonTeammatesNoSelf.find { it.name == event.entity.name } ?: return
-            teammate.entity = null
+        (event.entity as? EntityPlayer)?.let { player ->
+            dungeonTeammatesNoSelf.find { it.name == player.name }?.let { it.entity = null }
         }
     }
 


### PR DESCRIPTION
please merge before 1.3.5 release >_<

![image](https://github.com/user-attachments/assets/a7a6c2b7-6295-46b9-8fed-dae071215609)

renamed range to detection range
added prince strict mode
added dropdowns & rearrange

added blaze done message variants
unset DungeonPlayer.entity on EntityLeaveWorldEvent
(like if someone disconnect in front a prince crypt)